### PR TITLE
graphql output binding query variable support

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-bindings/graghql.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/graghql.md
@@ -39,6 +39,7 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 |--------------------|:--------:|------------|-----|---------|
 | endpoint | Y | Output | GraphQL endpoint string See [here](#url-format) for more details | `"http://localhost:4000/graphql/graphql"` |
 | header:[HEADERKEY] | N | Output | GraphQL header. Specify the header key in the `name`, and the header value in the `value`. | `"no-cache"` (see above) |
+| variable:[VARIABLEKEY] | N | Output | GraphQL query variable. Specify the variable name in the `name`, and the variable value in the `value`. | `"123"` (see below) |
 
 ### Endpoint and Header format
 
@@ -62,6 +63,18 @@ in := &dapr.InvokeBindingRequest{
 Name:      "example.bindings.graphql",
 Operation: "query",
 Metadata: map[string]string{ "query": `query { users { name } }`},
+}
+```
+
+To use a `query` that requires [query variables](https://graphql.org/learn/queries/#variables): add a key-value pair to the `metadata` map wherein every key corresponding to a query variable is the variable name prefixed with `variable:`
+
+```golang
+in := &dapr.InvokeBindingRequest{
+Name: "example.bindings.graphql",
+Operation: "query",
+Metadata: map[string]string{ 
+  "query": `query HeroNameAndFriends($episode: string!) { hero(episode: $episode) { name } }`,
+  "variable:episode": "JEDI",
 }
 ```
 

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/graghql.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/graghql.md
@@ -66,7 +66,7 @@ Metadata: map[string]string{ "query": `query { users { name } }`},
 }
 ```
 
-To use a `query` that requires [query variables](https://graphql.org/learn/queries/#variables): add a key-value pair to the `metadata` map wherein every key corresponding to a query variable is the variable name prefixed with `variable:`
+To use a `query` that requires [query variables](https://graphql.org/learn/queries/#variables), add a key-value pair to the `metadata` map, wherein every key corresponding to a query variable is the variable name prefixed with `variable:`
 
 ```golang
 in := &dapr.InvokeBindingRequest{


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

update the graphql doc corresponding to changes proposed by the [contrib-packages pr 2522](https://github.com/dapr/components-contrib/pull/2522) wherein query variable support is added to the gql output binding

## Issue reference

#3165
